### PR TITLE
Ignore missing imports on matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ select = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["numba.*",]
+module = ["numba.*","matplotlib.*"]
 ignore_missing_imports = true


### PR DESCRIPTION
Quick fix to mypy to ignore missing imports on matplotlib